### PR TITLE
Ensure torch 2.6+ compatibility, fix chain import and removal order in prune_program

### DIFF
--- a/nosbench/noslib.py
+++ b/nosbench/noslib.py
@@ -121,7 +121,7 @@ class NOSLib:
                 state_path = (self.path / str(stem)).with_suffix(".states")
                 states = []
                 if run.epochs > 0 and state_path.exists():
-                    states = torch.load(state_path)
+                    states = torch.load(state_path, weights_only=False)
                 else:
                     # Cached model is not available so train from scratch
                     run = Run(

--- a/nosbench/utils.py
+++ b/nosbench/utils.py
@@ -1,4 +1,5 @@
 from functools import wraps
+from itertools import chain
 
 import torch
 

--- a/nosbench/utils.py
+++ b/nosbench/utils.py
@@ -29,7 +29,7 @@ def prune_program(prog):
                 if instruction.output == next.output:
                     if i != len(prog) - 1:
                         remove.add(i)
-        for index in reversed(list(remove)):
+        for index in sorted(list(remove),reverse=True):
             prog.pop(index)
         if len(remove) == 0:
             return


### PR DESCRIPTION
PyTorch 2.6+ changed the default behaviour of torch.load() to weights_only=True. This blocks loading full model objects by default for security reasons.
Setting weights_only to False will load the entire model, bypassing the new restriction.
Source: https://medium.com/@roscoe.kerby/fixing-the-weights-only-load-failed-error-in-pytorch-9098d0a44a9a

Also adding `from itertools import chain`, as it is needed to import and run `prune_program`.

Also when removing redundant lines in `prune_program`, converting the set to a list did not sort it, meaning it could happen that earlier lines were removed first and then later lines became mis-indexed, leading to wrongly deleted lines, or `out of range`-errors.